### PR TITLE
Resolve for 'No module named Image' issue

### DIFF
--- a/matroschka.py
+++ b/matroschka.py
@@ -1,4 +1,8 @@
-import Image
+try:
+    import Image
+except:
+    from PIL import Image
+
 import argparse
 import hashlib
 import hmac

--- a/steganohide.py
+++ b/steganohide.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import Image
+try:
+    import Image
+except:
+    from PIL import Image
+
 import itertools
 
 


### PR DESCRIPTION
## Issue:
- Encounter `ImportError: No module named Image`
## Solution:
- Resolve by installing Pillow `pip install image`
- using `from PIL import Image`
