### PR TITLE
return a 'No message was extracted' message if stg.extract() returns

### DIFF
--- a/matroschka.py
+++ b/matroschka.py
@@ -119,6 +119,10 @@ def decrypt():
     image = Image.open(args['image'])
     matroschka = stg.extract_msg(image)
 
+    if matroschka is None:
+        print "No message was extracted"
+        return 1
+
     # get the 8 byte iv and the encrypted secret from the image data
     data_type, iv, encrypted_secret = matroschka.split('--:--')
 


### PR DESCRIPTION
This PR fixes the error that occurs when a message cannot be decoded:

Example error:
```
Traceback (most recent call last):
  File "matroschka.py", line 191, in <module>
    decrypt()
  File "matroschka.py", line 125, in decrypt
    data_type, iv, encrypted_secret = matroschka.split('--:--')
AttributeError: 'NoneType' object has no attribute 'split'
```

After PR will return:
`No message was extracted`
